### PR TITLE
Various fixes

### DIFF
--- a/scripts/yocto_ex.shader
+++ b/scripts/yocto_ex.shader
@@ -73,6 +73,7 @@ textures/yocto_ex/light2_blue_10k
 	qer_editorImage textures/shared_ex_src/light2_d
 
 	q3map_surfacelight 10000
+	q3map_backSplash 1 23
 	q3map_lightRGB .482 .702 1
 
 	{
@@ -94,6 +95,7 @@ textures/yocto_ex/light2_blue_20k
 	qer_editorImage textures/shared_ex_src/light2_d
 
 	q3map_surfacelight 20000
+	q3map_backSplash 1 23
 	q3map_lightRGB .482 .702 1
 
 	{

--- a/scripts/yocto_q4power.shader
+++ b/scripts/yocto_q4power.shader
@@ -16,6 +16,7 @@ textures/yocto_q4power/light_ceil1_yellow
 	qer_editorImage textures/yocto_q4power_src/light_ceil1_yellow_a
 
 	q3map_surfacelight 14000
+	q3map_backSplash 1 23
 	q3map_lightRGB 1 .8 0
 
 	surfaceparm nomarks
@@ -32,6 +33,7 @@ textures/yocto_q4power/light_fifty_yellow
 	qer_editorImage textures/yocto_q4power_src/light_fifty_yellow_a
 
 	q3map_surfacelight 10000
+	q3map_backSplash 1 23
 	q3map_lightRGB 1 .8 0
 
 	surfaceparm nomarks
@@ -55,6 +57,7 @@ textures/yocto_q4power/light_ceil1_magenta
 	qer_editorImage textures/yocto_q4power_src/light_ceil1_magenta_a
 
 	q3map_surfacelight 16000
+	q3map_backSplash 1 23
 	q3map_lightRGB 1 .2 1
 
 	surfaceparm nomarks
@@ -71,6 +74,7 @@ textures/yocto_q4power/light_fifty_magenta
 	qer_editorImage textures/yocto_q4power_src/light_fifty_magenta_a
 
 	q3map_surfacelight 12000
+	q3map_backSplash 1 23
 	q3map_lightRGB 1 .2 1
 
 	surfaceparm nomarks
@@ -94,6 +98,7 @@ textures/yocto_q4power/light_r1_magenta
 	qer_editorImage textures/yocto_q4power_src/light_r1_magenta_a
 
 	q3map_surfacelight 12000
+	q3map_backSplash 1 23
 	q3map_lightRGB 1 .2 1
 
 	surfaceparm nomarks
@@ -112,6 +117,7 @@ textures/yocto_q4power/light_r1_magenta_strong
 	qer_editorImage textures/yocto_q4power_src/light_r1_d
 
 	q3map_surfacelight 18000
+	q3map_backSplash 1 23
 	q3map_lightRGB 1 .2 1
 
 	surfaceparm nomarks
@@ -130,6 +136,7 @@ textures/yocto_q4power/light_fifty1_magenta
 	qer_editorImage textures/yocto_q4power_src/light_fifty1_magenta_a
 
 	q3map_surfacelight 12000
+	q3map_backSplash 1 23
 	q3map_lightRGB 1 .2 1
 
 	surfaceparm nomarks
@@ -154,6 +161,7 @@ textures/yocto_q4power/light_r1_blue
 	qer_editorImage textures/yocto_q4power_src/light_r1_blue_a
 
 	q3map_surfacelight 14000
+	q3map_backSplash 1 23
 	q3map_lightRGB .4 .7 1
 
 	surfaceparm nomarks
@@ -172,6 +180,7 @@ textures/yocto_q4power/light_r1_blue_strong
 	qer_editorImage textures/yocto_q4power_src/light_r1_h
 
 	q3map_surfacelight 28000
+	q3map_backSplash 1 23
 	q3map_lightRGB .4 .7 1
 
 	surfaceparm nomarks
@@ -190,6 +199,7 @@ textures/yocto_q4power/light_fifty_blue
 	qer_editorImage textures/yocto_q4power_src/light_fifty_blue_a
 
 	q3map_surfacelight 14000
+	q3map_backSplash 1 23
 	q3map_lightRGB .4 .7 1
 
 	surfaceparm nomarks
@@ -213,6 +223,7 @@ textures/yocto_q4power/light_fifty_blue_strong
 	qer_editorImage textures/yocto_q4power_src/light_fifty_blue_a
 
 	q3map_surfacelight 25000
+	q3map_backSplash 1 23
 	q3map_lightRGB .4 .7 1
 
 	surfaceparm nomarks
@@ -236,6 +247,7 @@ textures/yocto_q4power/light_fifty1_blue
 	qer_editorImage textures/yocto_q4power_src/light_fifty1_blue_a
 
 	q3map_surfacelight 15000
+	q3map_backSplash 1 23
 	q3map_lightRGB .4 .7 1
 
 	surfaceparm nomarks
@@ -259,6 +271,7 @@ textures/yocto_q4power/light_flouro1_blue
 	qer_editorImage textures/yocto_q4power_src/light_flouro1_blue_a
 
 	q3map_surfacelight 10000
+	q3map_backSplash 1 23
 	q3map_lightRGB .4 .7 1
 
 	surfaceparm nomarks
@@ -277,6 +290,7 @@ textures/yocto_q4power/light_flouro1_blue_strong
 	qer_editorImage textures/yocto_q4power_src/light_flouro1_d
 
 	q3map_surfacelight 18000
+	q3map_backSplash 1 23
 	q3map_lightRGB .4 .7 1
 
 	surfaceparm nomarks


### PR DESCRIPTION
Fix various stuff, either because it's buggy to begin with, or because it would look better with new build options.

- Some lights stuck in ceiling. Because of technical reasons the backsplash was painted but the emitted light itself wasn't and the surface wasn't visible, as it was stuck in geometry.

Before:

![unvanquished_2026-03-10_220252_000](https://github.com/user-attachments/assets/da05c498-2413-40cc-b3a6-0f75bea8d9a5)

After:

![unvanquished_2026-03-10_231033_000](https://github.com/user-attachments/assets/8ea60c44-6e9c-4b20-b5bf-0218fefad55f)

- A surface was mistakenly caulked, not visible by most players while in action, but small aliens like dretches can easily sport it.

Before:

![unvanquished_2026-03-11_152402_000](https://github.com/user-attachments/assets/37f6616a-6e12-458f-98d9-672245c3698d)

After:

![unvanquished_2026-03-11_160950_000](https://github.com/user-attachments/assets/d5a8c4ad-0d83-4cf8-94ec-8e6bfa5da108)

- Some light backsplash were dimmed, basically to fit some newer build options

Before:

![unvanquished_2026-03-11_161223_000](https://github.com/user-attachments/assets/9ddd24a6-2b10-4d57-b8ee-b2b161e24f8b)

After:

![unvanquished_2026-03-11_161258_000](https://github.com/user-attachments/assets/b4950d93-24ce-4cb4-a8bc-a283789415e3)

For reference, here is how it looks in 0.55.5:

![unvanquished_2026-03-11_162246_000](https://github.com/user-attachments/assets/96d80e4c-1ea4-4544-b9be-2859d34185c2)

That 0.55.5 screenshot is **_not_** using tone mapping because tone mapping wasn't properly calibrated for Unvanquished needs yet, while all the other screenshots above are using tone mapping and the latest `for-0.56.0/sync` branch. So when comparing, keep that in mind that tone mapping contrast darkens images a bit, despite us having nerfed the contrast.

As a remind, here it how it looks on 0.55.5 with tone mapping enabled but with such tone mapping not being calibrated for our needs yet (over exposure being a byproduct of that, and contrast could not hide it anyway). It is now up to the one wanting to reproduce this look on his end to crank exposure up:

![unvanquished_2026-03-11_162301_000](https://github.com/user-attachments/assets/85f987bb-3e11-49b7-91ae-d2d7e7928909)

That last screenshot isn't usable for comparison. See those threads on calibrating the tone mapper:

- https://github.com/DaemonEngine/Daemon/issues/1865
- https://github.com/DaemonEngine/Daemon/issues/1913
- https://github.com/DaemonEngine/Daemon/pull/1884
- https://github.com/DaemonEngine/Daemon/pull/1912
- https://github.com/DaemonEngine/Daemon/pull/1915

Now with all those fixes the lighting is more reliable making easier for people to tweak them as they like on their side with engine options thanks for now having a solid base to start from.